### PR TITLE
Avoid returning None in Set.getComponentTagMap.

### DIFF
--- a/pyasn1/type/univ.py
+++ b/pyasn1/type/univ.py
@@ -2144,7 +2144,8 @@ class Set(SequenceAndSetBase):
     def getComponentTagMap(self):
         if self._componentType:
             return self._componentType.getTagMap(True)
-
+        return tagmap.TagMap()
+        
     def getComponentPositionByType(self, tagSet):
         if self._componentType:
             return self._componentType.getPositionByType(tagSet)


### PR DESCRIPTION
Return empty TagMap as a fallback.